### PR TITLE
Correct Readme.md include path

### DIFF
--- a/StandardTemplates/HabitatStyle.Project.Module/src/Project/$modulename$/code/$modulenamespace$.csproj
+++ b/StandardTemplates/HabitatStyle.Project.Module/src/Project/$modulename$/code/$modulenamespace$.csproj
@@ -100,7 +100,7 @@
     <Content Include="App_Config\Include\Project\$moduleNamespace$.config" />
     <Content Include="App_Config\Include\Project\$moduleNamespace$.Serialization.config" />
     <None Include="Properties\PublishProfiles\Local.pubxml" />
-    <None Include="\README.md" />
+    <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
The Readme.md file is created on disc, but the lead slash on the include seems to resolve to the drive's root - e.g. c:\readme.md - which is not correct.